### PR TITLE
Add newman builder

### DIFF
--- a/builder-newman/Dockerfile
+++ b/builder-newman/Dockerfile
@@ -1,0 +1,3 @@
+FROM jenkinsxio/builder-nodejs:1
+
+RUN npm install -g newman

--- a/builder-newman/README.md
+++ b/builder-newman/README.md
@@ -1,0 +1,3 @@
+# builder-newman
+
+This is the image used in the Jenkins X platform to run Postman Collections with Newman.


### PR DESCRIPTION
Addition of a newman builder. Newman is a command-line tool for running Postman Collections. The newman builder image will be useful for executing acceptance tests against preview environments.

The jx-docker-build.sh script was modified to support builder images that depend on builder images other than builder-base.