### PR TITLE
add maven-java11 to docker build file

### DIFF
--- a/jx-docker-build.sh
+++ b/jx-docker-build.sh
@@ -78,6 +78,7 @@ if [ "release" == "${RELEASE}" ]; then
     jenkinsxio/builder-go-maven ${VERSION} \
     jenkinsxio/builder-gradle ${VERSION} \
     jenkinsxio/builder-maven ${VERSION} \
+    jenkinsxio/builder-maven-java11 ${VERSION} \
     jenkinsxio/builder-newman ${VERSION} \
     jenkinsxio/builder-nodejs ${VERSION} \
     jenkinsxio/builder-python ${VERSION} \


### PR DESCRIPTION
Just noticed that the maven-java11 docker image was missing on docker hub.
I'm not sure if this will fix this, but it was still missing in the build file.
