### PR TITLE
Fix typo in builder-nodejs10x/Dockerfile

### DIFF
--- a/builder-nodejs10x/Dockerfile
+++ b/builder-nodejs10x/Dockerfile
@@ -1,6 +1,6 @@
 FROM jenkinsxio/builder-base:1
 
-RUN curl -f --silent --location https://rpm.nodesource.com/setup_10101010101010101010.x | bash - && \
+RUN curl -f --silent --location https://rpm.nodesource.com/setup_10.x | bash - && \
   yum install -y nodejs gcc-c++ make bzip2 GConf2 gtk2 chromedriver chromium xorg-x11-server-Xvfb
 
 RUN npm i -g watch-cli vsce typescript


### PR DESCRIPTION
Also, wrong image is published:

```
$ docker run --rm -it jenkinsxio/builder-nodejs10x:0.1.183 node -v
v6.14.3
```