### PR TITLE
Add terragrunt to terraform builder

### DIFF
--- a/builder-terraform/Dockerfile
+++ b/builder-terraform/Dockerfile
@@ -1,8 +1,13 @@
 FROM jenkinsxio/builder-base:1
 
-ENV TERRAFORM 0.11.10
+ENV TERRAFORM 0.11.11
 RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM}/terraform_${TERRAFORM}_linux_amd64.zip && \
   unzip terraform_${TERRAFORM}_linux_amd64.zip && \
   chmod +x terraform && mv terraform /usr/bin/terraform && rm terraform_${TERRAFORM}_linux_amd64.zip
+
+ENV TERRAGRUNT_VERSION 0.17.4
+RUN curl -f -Lo terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 && \
+  chmod +x terragrunt && \
+  mv terragrunt /usr/bin
 
 ENV PATH $PATH:/usr/local/


### PR DESCRIPTION
Also update terraform to 0.11.11 from 0.11.10.

For more information on terragrunt: https://github.com/gruntwork-io/terragrunt

The tl;dr of terragrunt is that it helps to manage remote state and to run `terraform apply`, etc across all of your modules (AKA your stack).

I included terragrunt in the terraform builder because it depends on the terraform binary being in the path.