### PR TITLE
Add dep as dependency manager

### DIFF
--- a/builder-go/Dockerfile
+++ b/builder-go/Dockerfile
@@ -16,6 +16,10 @@ RUN wget https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/g
   mv linux-amd64 /usr/local/glide && \
   rm glide-$GLIDE_VERSION-linux-amd64.tar.gz
 
+ENV DEP_VERSION v0.5.0
+RUN wget https://github.com/golang/dep/releases/download/$DEP_VERSION/dep-linux-amd64 && chmod +x dep-linux-amd64 && \
+  mv dep-linux-amd64 /usr/local/dep
+
 ENV GH_RELEASE_VERSION 2.2.1
 RUN wget https://github.com/progrium/gh-release/releases/download/v$GH_RELEASE_VERSION/gh-release_${GH_RELEASE_VERSION}_linux_x86_64.tgz && \
   tar -xzf gh-release_${GH_RELEASE_VERSION}_linux_x86_64.tgz && \
@@ -33,6 +37,7 @@ RUN wget https://github.com/google/protobuf/releases/download/v${PROTOBUF}/proto
 
 ENV PATH $PATH:/usr/local/go/bin
 ENV PATH $PATH:/usr/local/glide
+ENV PATH $PATH:/usr/local/dep
 ENV PATH $PATH:/usr/local/
 ENV GOROOT /usr/local/go
 ENV GOPATH=/home/jenkins/go


### PR DESCRIPTION
This PR adds `dep` to the builder-go image.