### PR TITLE
Fix rpm link.

### DIFF
--- a/builder-nodejs10x/Dockerfile
+++ b/builder-nodejs10x/Dockerfile
@@ -1,6 +1,6 @@
 FROM jenkinsxio/builder-base:1
 
-RUN curl -f --silent --location https://rpm.nodesource.com/setup_10101010101010101010.x | bash - && \
+RUN curl -f --silent --location https://rpm.nodesource.com/setup_10.x | bash - && \
   yum install -y nodejs gcc-c++ make bzip2 GConf2 gtk2 chromedriver chromium xorg-x11-server-Xvfb
 
 RUN npm i -g watch-cli vsce typescript


### PR DESCRIPTION
Current link to downloand the rpm package (node.js 10) is wrong. This pr is a small fix with the correct url. 