### PR TITLE
Removed unnecessary packages from newman builder image dockerfile.

### DIFF
--- a/builder-newman/Dockerfile
+++ b/builder-newman/Dockerfile
@@ -1,16 +1,9 @@
 FROM jenkinsxio/builder-base:0.0.0-SNAPSHOT-PR-183-12
 
 RUN curl -f --silent --location https://rpm.nodesource.com/setup_9.x | bash - && \
-  yum install -y nodejs gcc-c++ make bzip2 GConf2 gtk2 chromedriver chromium xorg-x11-server-Xvfb && \
+  yum install -y nodejs && \
   yum clean all
 
-RUN npm i -g watch-cli vsce typescript
-
-# Yarn
-ENV YARN_VERSION 1.3.2
-RUN curl -f -L -o /tmp/yarn.tgz https://github.com/yarnpkg/yarn/releases/download/v${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz && \	
-	tar xf /tmp/yarn.tgz && \
-	mv yarn-v${YARN_VERSION} /opt/yarn && \
-	ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn
-
 RUN npm install -g newman
+
+CMD ["newman", "--version"]


### PR DESCRIPTION
The newman builder image installs a lot of packages that are not needed to run newman.  This PR removes them and adds a line to print the version of newman to verify its installation. 