### PR TITLE
Upgrade Terragrunt to 0.19.4

### DIFF
--- a/builder-terraform/Dockerfile
+++ b/builder-terraform/Dockerfile
@@ -5,7 +5,7 @@ RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM}/terraform_${TERRA
   unzip terraform_${TERRAFORM}_linux_amd64.zip && \
   chmod +x terraform && mv terraform /usr/bin/terraform && rm terraform_${TERRAFORM}_linux_amd64.zip
 
-ENV TERRAGRUNT_VERSION 0.17.4
+ENV TERRAGRUNT_VERSION 0.19.4
 RUN curl -f -Lo terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64 && \
   chmod +x terragrunt && \
   mv terragrunt /usr/bin


### PR DESCRIPTION
You must use Terragrunt `0.19` and above with Terraform `0.12`. There are breaking changes to Terragrunt `0.19`, see their [docs for details](https://github.com/gruntwork-io/terragrunt/blob/master/_docs/migration_guides/upgrading_to_terragrunt_0.19.x.md).