### PR TITLE
Update jx to 2.0.376 for builder-go

### DIFF
--- a/builder-go/Dockerfile
+++ b/builder-go/Dockerfile
@@ -67,7 +67,7 @@ RUN go get gotest.tools/gotestsum && \
   rm -rf $GOPATH/src/gotest.tools
 
 # jx
-ENV JX_VERSION 2.0.372
+ENV JX_VERSION 2.0.376
 RUN curl -f -L https://github.com/jenkins-x/jx/releases/download/v${JX_VERSION}/jx-linux-amd64.tar.gz | tar xzv && \
   mv jx /usr/bin/
 


### PR DESCRIPTION
This is just to unblock me waiting for the update bot to do its job.

It we never be merged.