### PR TITLE
chore: Disabling building and updating of ML builders for now.

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -182,24 +182,25 @@ pipelineConfig:
                 - --cache-repo=gcr.io/jenkinsxio/cache
                 - --cache=true
                 - --cache-dir=/workspace
-            - name: build-and-push-machine-learning
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-machine-learning/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-machine-learning:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-machine-learning-gpu
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-machine-learning-gpu/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-machine-learning-gpu:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
+#  TODO: Skipping machine learning until we have a more efficient way to build them
+#            - name: build-and-push-machine-learning
+#              command: /kaniko/executor
+#              args:
+#                - --dockerfile=/workspace/source/builder-machine-learning/Dockerfile
+#                - --destination=gcr.io/jenkinsxio/builder-machine-learning:${inputs.params.version}
+#                - --context=/workspace/source
+#                - --cache-repo=gcr.io/jenkinsxio/cache
+#                - --cache=true
+#                - --cache-dir=/workspace
+#            - name: build-and-push-machine-learning-gpu
+#              command: /kaniko/executor
+#              args:
+#                - --dockerfile=/workspace/source/builder-machine-learning-gpu/Dockerfile
+#                - --destination=gcr.io/jenkinsxio/builder-machine-learning-gpu:${inputs.params.version}
+#                - --context=/workspace/source
+#                - --cache-repo=gcr.io/jenkinsxio/cache
+#                - --cache=true
+#                - --cache-dir=/workspace
             - name: build-and-push-maven
               command: /kaniko/executor
               args:
@@ -492,24 +493,25 @@ pipelineConfig:
                 - --cache-repo=gcr.io/jenkinsxio/cache
                 - --cache=true
                 - --cache-dir=/workspace
-            - name: build-and-push-machine-learning
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-machine-learning/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-machine-learning:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-machine-learning-gpu
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-machine-learning-gpu/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-machine-learning-gpu:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
+#  TODO: Skipping machine learning until we have a more efficient way to build them
+#            - name: build-and-push-machine-learning
+#              command: /kaniko/executor
+#              args:
+#                - --dockerfile=/workspace/source/builder-machine-learning/Dockerfile
+#                - --destination=gcr.io/jenkinsxio/builder-machine-learning:${inputs.params.version}
+#                - --context=/workspace/source
+#                - --cache-repo=gcr.io/jenkinsxio/cache
+#                - --cache=true
+#                - --cache-dir=/workspace
+#            - name: build-and-push-machine-learning-gpu
+#              command: /kaniko/executor
+#              args:
+#                - --dockerfile=/workspace/source/builder-machine-learning-gpu/Dockerfile
+#                - --destination=gcr.io/jenkinsxio/builder-machine-learning-gpu:${inputs.params.version}
+#                - --context=/workspace/source
+#                - --cache-repo=gcr.io/jenkinsxio/cache
+#                - --cache=true
+#                - --cache-dir=/workspace
             - name: build-and-push-maven
               command: /kaniko/executor
               args:

--- a/update-bot.sh
+++ b/update-bot.sh
@@ -13,8 +13,9 @@ jx step create pr chart --name gcr.io/jenkinsxio/builder-gradle --version ${VERS
 jx step create pr chart --name gcr.io/jenkinsxio/builder-gradle4 --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
 jx step create pr chart --name gcr.io/jenkinsxio/builder-gradle5 --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
 jx step create pr chart --name gcr.io/jenkinsxio/builder-jx --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-machine-learning --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-machine-learning-gpu --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
+# TODO: Skipping machine learning builders until we have a more efficient way to build them.
+#jx step create pr chart --name gcr.io/jenkinsxio/builder-machine-learning --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
+#jx step create pr chart --name gcr.io/jenkinsxio/builder-machine-learning-gpu --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
 jx step create pr chart --name gcr.io/jenkinsxio/builder-maven --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git --repo https://github.com/jenkins-x-charts/environment-controller.git --repo https://github.com/jenkins-x-charts/prow.git
 jx step create pr chart --name gcr.io/jenkinsxio/builder-maven-32 --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
 jx step create pr chart --name gcr.io/jenkinsxio/builder-maven-java11 --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git


### PR DESCRIPTION
They just take too long and there's reason to believe they're so big
that they're causing issues with Kaniko. Some discussion in
https://github.com/jenkins-x/jx/issues/4671, but yeah, we need to find
a better way to build them. For now, this will leave the existing
images in place for the time being.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>