### PR TITLE
fix: One `jx step create pr chart` call for all of jenkins-x-platform

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -566,7 +566,7 @@ pipelineConfig:
               command: /kaniko/executor
               args:
                 - --dockerfile=/workspace/source/builder-nodejs10x/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-nodejs8x:${inputs.params.version}
+                - --destination=gcr.io/jenkinsxio/builder-nodejs10x:${inputs.params.version}
                 - --context=/workspace/source
                 - --cache-repo=gcr.io/jenkinsxio/cache
                 - --cache=true

--- a/update-bot.sh
+++ b/update-bot.sh
@@ -4,32 +4,17 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-jx step create pr chart --name gcr.io/jenkinsxio/builder-ruby --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-swift --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-dlang --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-go --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-go-maven --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-gradle --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-gradle4 --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-gradle5 --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-jx --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-# TODO: Skipping machine learning builders until we have a more efficient way to build them.
-#jx step create pr chart --name gcr.io/jenkinsxio/builder-machine-learning --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-#jx step create pr chart --name gcr.io/jenkinsxio/builder-machine-learning-gpu --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-maven --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git --repo https://github.com/jenkins-x-charts/environment-controller.git --repo https://github.com/jenkins-x-charts/prow.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-maven-32 --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-maven-java11 --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-maven-nodejs --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-newman --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-nodejs --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-nodejs8x --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-nodejs10x --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-python --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-python2 --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-python37 --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-rust --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-scala --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
-jx step create pr chart --name gcr.io/jenkinsxio/builder-terraform --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
+jx step create pr chart --name gcr.io/jenkinsxio/builder-ruby --name gcr.io/jenkinsxio/builder-swift \
+  --name gcr.io/jenkinsxio/builder-dlang --name gcr.io/jenkinsxio/builder-go --name gcr.io/jenkinsxio/builder-go-maven \
+  --name gcr.io/jenkinsxio/builder-gradle --name gcr.io/jenkinsxio/builder-gradle4 --name gcr.io/jenkinsxio/builder-gradle5 \
+  --name gcr.io/jenkinsxio/builder-jx --name gcr.io/jenkinsxio/builder-maven --name gcr.io/jenkinsxio/builder-maven-32 \
+  --name gcr.io/jenkinsxio/builder-maven-java11 --name gcr.io/jenkinsxio/builder-maven-nodejs --name gcr.io/jenkinsxio/builder-newman \
+  --name gcr.io/jenkinsxio/builder-nodejs --name gcr.io/jenkinsxio/builder-nodejs8x --name gcr.io/jenkinsxio/builder-nodejs10x \
+  --name gcr.io/jenkinsxio/builder-python --name gcr.io/jenkinsxio/builder-python2 --name gcr.io/jenkinsxio/builder-python37 \
+  --name gcr.io/jenkinsxio/builder-rust --name gcr.io/jenkinsxio/builder-scala --name gcr.io/jenkinsxio/builder-terraform \
+  --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
+
+jx step create pr chart --name gcr.io/jenkinsxio/builder-maven --version ${VERSION} --repo https://github.com/jenkins-x-charts/environment-controller.git --repo https://github.com/jenkins-x-charts/prow.git
 
 jx step create pr regex --regex "builderTag: (.*)" --version ${VERSION} --files jx-build-templates/values.yaml --repo https://github.com/jenkins-x-charts/jx-build-templates.git
 jx step create pr regex --regex "(?m)^\s+repository: gcr.io/jenkinsxio/builder-[\w-_]+\s+tag: (?P<version>.*)$" --version ${VERSION} --files jenkins-x-platform/values.yaml --files values.yaml --repo https://github.com/jenkins-x/jenkins-x-platform.git


### PR DESCRIPTION
Also fixed the tag for `nodejs10x`, which was pushing on release to `nodejs8x`. Oops.

Relates to https://github.com/jenkins-x/jx/issues/4771, depends on https://github.com/jenkins-x/jx/pull/4777, which will be in the relevant builder starting with https://github.com/jenkins-x/jenkins-x-builders/pull/582

/assign @pmuir 
/assign @warrenbailey 