### PR TITLE
feat: Run just the PR build in parallel

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -27,286 +27,478 @@ pipelineConfig:
                 value: jenkins-x@googlegroups.com
               - name: GIT_AUTHOR_NAME
                 value: jenkins-x-bot
-            steps:
-            - image: centos:7
-              command: ./replace-versions.sh
+            parallel:
+              - name: batch-one
+                steps:
+                - image: centos:7
+                  command: ./replace-versions.sh
 
-            - image: jenkinsxio/jx:1.3.963
-              command: jx
-              args:
-                - step
-                - credential
-                - -s
-                - kaniko-secret
-                - -k
-                - kaniko-secret
-                - -f
-                - /builder/home/kaniko-secret.json
+                - image: jenkinsxio/jx:1.3.963
+                  command: jx
+                  args:
+                    - step
+                    - credential
+                    - -s
+                    - kaniko-secret
+                    - -k
+                    - kaniko-secret
+                    - -f
+                    - /builder/home/kaniko-secret.json
 
-            # cache base images
-            - name: warm-cache
-              image: gcr.io/kaniko-project/warmer
-              command: /kaniko/warmer
-              args:
-                - --cache-dir=/workspace
-                - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
-                - --image=gcr.io/jenkinsxio/builder-base:0.0.45
-                - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
+                # cache base images
+                - name: warm-cache
+                  image: gcr.io/kaniko-project/warmer
+                  command: /kaniko/warmer
+                  args:
+                    - --cache-dir=/workspace
+                    - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
+                    - --image=gcr.io/jenkinsxio/builder-base:0.0.45
+                    - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
 
-            # builders
-            - name: build-and-push-maven-java11
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-maven-java11/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-maven-java11:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-maven-graalvm
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-maven-graalvm/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-maven-graalvm:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-maven-nodejs
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-maven-nodejs/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-maven-nodejs:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-cf
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-cf/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-cf:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-go
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-go/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-python37
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-python37/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-python37:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-go-maven
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-go-maven/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-go-maven:${inputs.params.version}
-                - --context=/workspace/source/builder-go-maven
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-jx
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-jx/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-jx:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-python
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-python/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-python:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-maven-32
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-maven-32/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-maven-32:${inputs.params.version}
-                - --context=/workspace/source/builder-maven-32
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-dlang
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-dlang/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-dlang:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-gradle
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-gradle/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-gradle:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-gradle4
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-gradle4/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-gradle4:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-gradle5
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-gradle5/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-gradle5:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-gradle5-java11
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-gradle5-java11/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-gradle5-java11:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-#  TODO: Skipping machine learning until we have a more efficient way to build them
-#            - name: build-and-push-machine-learning
-#              command: /kaniko/executor
-#              args:
-#                - --dockerfile=/workspace/source/builder-machine-learning/Dockerfile
-#                - --destination=gcr.io/jenkinsxio/builder-machine-learning:${inputs.params.version}
-#                - --context=/workspace/source
-#                - --cache-repo=gcr.io/jenkinsxio/cache
-#                - --cache=true
-#                - --cache-dir=/workspace
-#            - name: build-and-push-machine-learning-gpu
-#              command: /kaniko/executor
-#              args:
-#                - --dockerfile=/workspace/source/builder-machine-learning-gpu/Dockerfile
-#                - --destination=gcr.io/jenkinsxio/builder-machine-learning-gpu:${inputs.params.version}
-#                - --context=/workspace/source
-#                - --cache-repo=gcr.io/jenkinsxio/cache
-#                - --cache=true
-#                - --cache-dir=/workspace
-            - name: build-and-push-maven
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-maven/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-maven:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-newman
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-newman/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-newman:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-nodejs
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-nodejs/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-nodejs:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-nodejs8x
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-nodejs8x/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-nodejs8x:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-nodejs10x
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-nodejs10x/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-nodejs10x:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-python2
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-python2/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-python2:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-ruby
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-ruby/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-ruby:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-rust
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-rust/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-rust:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-scala
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-scala/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-scala:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-swift
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-swift/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-swift:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-terraform
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-terraform/Dockerfile
-                - --destination=gcr.io/jenkinsxio/builder-terraform:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
+                # builders
+                - name: build-and-push-maven-java11
+                  command: /kaniko/executor
+                  args:
+                    - --dockerfile=/workspace/source/builder-maven-java11/Dockerfile
+                    - --destination=gcr.io/jenkinsxio/builder-maven-java11:${inputs.params.version}
+                    - --context=/workspace/source
+                    - --cache-repo=gcr.io/jenkinsxio/cache
+                    - --cache=true
+                    - --cache-dir=/workspace
+                - name: build-and-push-maven-graalvm
+                  command: /kaniko/executor
+                  args:
+                    - --dockerfile=/workspace/source/builder-maven-graalvm/Dockerfile
+                    - --destination=gcr.io/jenkinsxio/builder-maven-graalvm:${inputs.params.version}
+                    - --context=/workspace/source
+                    - --cache-repo=gcr.io/jenkinsxio/cache
+                    - --cache=true
+                    - --cache-dir=/workspace
+                - name: build-and-push-maven-nodejs
+                  command: /kaniko/executor
+                  args:
+                    - --dockerfile=/workspace/source/builder-maven-nodejs/Dockerfile
+                    - --destination=gcr.io/jenkinsxio/builder-maven-nodejs:${inputs.params.version}
+                    - --context=/workspace/source
+                    - --cache-repo=gcr.io/jenkinsxio/cache
+                    - --cache=true
+                    - --cache-dir=/workspace
+              - name: batch-two
+                steps:
+                  - image: centos:7
+                    command: ./replace-versions.sh
+
+                  - image: jenkinsxio/jx:1.3.963
+                    command: jx
+                    args:
+                      - step
+                      - credential
+                      - -s
+                      - kaniko-secret
+                      - -k
+                      - kaniko-secret
+                      - -f
+                      - /builder/home/kaniko-secret.json
+
+                  # cache base images
+                  - name: warm-cache
+                    image: gcr.io/kaniko-project/warmer
+                    command: /kaniko/warmer
+                    args:
+                      - --cache-dir=/workspace
+                      - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
+                      - --image=gcr.io/jenkinsxio/builder-base:0.0.45
+                      - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
+
+                  - name: build-and-push-cf
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-cf/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-cf:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-go
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-go/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-python37
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-python37/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-python37:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+              - name: batch-three
+                steps:
+                  - image: centos:7
+                    command: ./replace-versions.sh
+
+                  - image: jenkinsxio/jx:1.3.963
+                    command: jx
+                    args:
+                      - step
+                      - credential
+                      - -s
+                      - kaniko-secret
+                      - -k
+                      - kaniko-secret
+                      - -f
+                      - /builder/home/kaniko-secret.json
+
+                  # cache base images
+                  - name: warm-cache
+                    image: gcr.io/kaniko-project/warmer
+                    command: /kaniko/warmer
+                    args:
+                      - --cache-dir=/workspace
+                      - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
+                      - --image=gcr.io/jenkinsxio/builder-base:0.0.45
+                      - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
+                  - name: build-and-push-go-maven
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-go-maven/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-go-maven:${inputs.params.version}
+                      - --context=/workspace/source/builder-go-maven
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-jx
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-jx/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-jx:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-python
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-python/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-python:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+              - name: batch-four
+                steps:
+                  - image: centos:7
+                    command: ./replace-versions.sh
+
+                  - image: jenkinsxio/jx:1.3.963
+                    command: jx
+                    args:
+                      - step
+                      - credential
+                      - -s
+                      - kaniko-secret
+                      - -k
+                      - kaniko-secret
+                      - -f
+                      - /builder/home/kaniko-secret.json
+
+                  # cache base images
+                  - name: warm-cache
+                    image: gcr.io/kaniko-project/warmer
+                    command: /kaniko/warmer
+                    args:
+                      - --cache-dir=/workspace
+                      - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
+                      - --image=gcr.io/jenkinsxio/builder-base:0.0.45
+                      - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
+                  - name: build-and-push-maven-32
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-maven-32/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-maven-32:${inputs.params.version}
+                      - --context=/workspace/source/builder-maven-32
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-dlang
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-dlang/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-dlang:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-gradle
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-gradle/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-gradle:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+              - name: batch-five
+                steps:
+                  - image: centos:7
+                    command: ./replace-versions.sh
+
+                  - image: jenkinsxio/jx:1.3.963
+                    command: jx
+                    args:
+                      - step
+                      - credential
+                      - -s
+                      - kaniko-secret
+                      - -k
+                      - kaniko-secret
+                      - -f
+                      - /builder/home/kaniko-secret.json
+
+                  # cache base images
+                  - name: warm-cache
+                    image: gcr.io/kaniko-project/warmer
+                    command: /kaniko/warmer
+                    args:
+                      - --cache-dir=/workspace
+                      - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
+                      - --image=gcr.io/jenkinsxio/builder-base:0.0.45
+                      - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
+                  - name: build-and-push-gradle4
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-gradle4/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-gradle4:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-gradle5
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-gradle5/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-gradle5:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-gradle5-java11
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-gradle5-java11/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-gradle5-java11:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+              - name: batch-six
+                steps:
+                  - image: centos:7
+                    command: ./replace-versions.sh
+
+                  - image: jenkinsxio/jx:1.3.963
+                    command: jx
+                    args:
+                      - step
+                      - credential
+                      - -s
+                      - kaniko-secret
+                      - -k
+                      - kaniko-secret
+                      - -f
+                      - /builder/home/kaniko-secret.json
+
+                  # cache base images
+                  - name: warm-cache
+                    image: gcr.io/kaniko-project/warmer
+                    command: /kaniko/warmer
+                    args:
+                      - --cache-dir=/workspace
+                      - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
+                      - --image=gcr.io/jenkinsxio/builder-base:0.0.45
+                      - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
+                  - name: build-and-push-maven
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-maven/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-maven:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-newman
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-newman/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-newman:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-nodejs
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-nodejs/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-nodejs:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+              - name: batch-seven
+                steps:
+                  - image: centos:7
+                    command: ./replace-versions.sh
+
+                  - image: jenkinsxio/jx:1.3.963
+                    command: jx
+                    args:
+                      - step
+                      - credential
+                      - -s
+                      - kaniko-secret
+                      - -k
+                      - kaniko-secret
+                      - -f
+                      - /builder/home/kaniko-secret.json
+
+                  # cache base images
+                  - name: warm-cache
+                    image: gcr.io/kaniko-project/warmer
+                    command: /kaniko/warmer
+                    args:
+                      - --cache-dir=/workspace
+                      - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
+                      - --image=gcr.io/jenkinsxio/builder-base:0.0.45
+                      - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
+                  - name: build-and-push-nodejs8x
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-nodejs8x/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-nodejs8x:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-nodejs10x
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-nodejs10x/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-nodejs10x:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-python2
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-python2/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-python2:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+              - name: batch-eight
+                steps:
+                  - image: centos:7
+                    command: ./replace-versions.sh
+
+                  - image: jenkinsxio/jx:1.3.963
+                    command: jx
+                    args:
+                      - step
+                      - credential
+                      - -s
+                      - kaniko-secret
+                      - -k
+                      - kaniko-secret
+                      - -f
+                      - /builder/home/kaniko-secret.json
+
+                  # cache base images
+                  - name: warm-cache
+                    image: gcr.io/kaniko-project/warmer
+                    command: /kaniko/warmer
+                    args:
+                      - --cache-dir=/workspace
+                      - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
+                      - --image=gcr.io/jenkinsxio/builder-base:0.0.45
+                      - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
+                  - name: build-and-push-ruby
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-ruby/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-ruby:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-rust
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-rust/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-rust:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+              - name: batch-nine
+                steps:
+                  - image: centos:7
+                    command: ./replace-versions.sh
+
+                  - image: jenkinsxio/jx:1.3.963
+                    command: jx
+                    args:
+                      - step
+                      - credential
+                      - -s
+                      - kaniko-secret
+                      - -k
+                      - kaniko-secret
+                      - -f
+                      - /builder/home/kaniko-secret.json
+
+                  # cache base images
+                  - name: warm-cache
+                    image: gcr.io/kaniko-project/warmer
+                    command: /kaniko/warmer
+                    args:
+                      - --cache-dir=/workspace
+                      - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
+                      - --image=gcr.io/jenkinsxio/builder-base:0.0.45
+                      - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
+                  - name: build-and-push-scala
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-scala/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-scala:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-swift
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-swift/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-swift:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-terraform
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-terraform/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-terraform:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
 
     release:
       pipeline:


### PR DESCRIPTION
For the PR build, we don't need to share workspace state before/after
the builders themselves, so it should be more easily parallelizable.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>