### PR TITLE
chore: Cut down parallelism, try to get them to run on different nodes

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -7,9 +7,11 @@ pipelineConfig:
           containerOptions:
             resources:
               limits:
-                memory: 10Gi
+                memory: 16Gi
+                cpu: 3
               requests:
-                memory: 6Gi
+                memory: 12Gi
+                cpu: 2
           distributeParallelAcrossNodes: true
         agent:
           image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
@@ -370,9 +372,11 @@ pipelineConfig:
           containerOptions:
             resources:
               limits:
-                memory: 10Gi
+                memory: 16Gi
+                cpu: 3
               requests:
-                memory: 6Gi
+                memory: 12Gi
+                cpu: 2
         agent:
           image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
         stages:

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -10,6 +10,7 @@ pipelineConfig:
                 memory: 10Gi
               requests:
                 memory: 6Gi
+          distributeParallelAcrossNodes: true
         agent:
           image: gcr.io/kaniko-project/executor:9912ccbf8d22bbafbf971124600fbb0b13b9cbd6
         stages:
@@ -51,9 +52,7 @@ pipelineConfig:
                   command: /kaniko/warmer
                   args:
                     - --cache-dir=/workspace
-                    - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
                     - --image=gcr.io/jenkinsxio/builder-base:0.0.45
-                    - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
 
                 # builders
                 - name: build-and-push-maven-java11
@@ -83,6 +82,33 @@ pipelineConfig:
                     - --cache-repo=gcr.io/jenkinsxio/cache
                     - --cache=true
                     - --cache-dir=/workspace
+                - name: build-and-push-cf
+                  command: /kaniko/executor
+                  args:
+                    - --dockerfile=/workspace/source/builder-cf/Dockerfile
+                    - --destination=gcr.io/jenkinsxio/builder-cf:${inputs.params.version}
+                    - --context=/workspace/source
+                    - --cache-repo=gcr.io/jenkinsxio/cache
+                    - --cache=true
+                    - --cache-dir=/workspace
+                - name: build-and-push-go
+                  command: /kaniko/executor
+                  args:
+                    - --dockerfile=/workspace/source/builder-go/Dockerfile
+                    - --destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                    - --context=/workspace/source
+                    - --cache-repo=gcr.io/jenkinsxio/cache
+                    - --cache=true
+                    - --cache-dir=/workspace
+                - name: build-and-push-python37
+                  command: /kaniko/executor
+                  args:
+                    - --dockerfile=/workspace/source/builder-python37/Dockerfile
+                    - --destination=gcr.io/jenkinsxio/builder-python37:${inputs.params.version}
+                    - --context=/workspace/source
+                    - --cache-repo=gcr.io/jenkinsxio/cache
+                    - --cache=true
+                    - --cache-dir=/workspace
               - name: batch-two
                 steps:
                   - image: centos:7
@@ -106,33 +132,57 @@ pipelineConfig:
                     command: /kaniko/warmer
                     args:
                       - --cache-dir=/workspace
-                      - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
                       - --image=gcr.io/jenkinsxio/builder-base:0.0.45
-                      - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
-
-                  - name: build-and-push-cf
+                  - name: build-and-push-go-maven
                     command: /kaniko/executor
                     args:
-                      - --dockerfile=/workspace/source/builder-cf/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-cf:${inputs.params.version}
+                      - --dockerfile=/workspace/source/builder-go-maven/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-go-maven:${inputs.params.version}
+                      - --context=/workspace/source/builder-go-maven
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-jx
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-jx/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-jx:${inputs.params.version}
                       - --context=/workspace/source
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true
                       - --cache-dir=/workspace
-                  - name: build-and-push-go
+                  - name: build-and-push-python
                     command: /kaniko/executor
                     args:
-                      - --dockerfile=/workspace/source/builder-go/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                      - --dockerfile=/workspace/source/builder-python/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-python:${inputs.params.version}
                       - --context=/workspace/source
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true
                       - --cache-dir=/workspace
-                  - name: build-and-push-python37
+                  - name: build-and-push-maven-32
                     command: /kaniko/executor
                     args:
-                      - --dockerfile=/workspace/source/builder-python37/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-python37:${inputs.params.version}
+                      - --dockerfile=/workspace/source/builder-maven-32/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-maven-32:${inputs.params.version}
+                      - --context=/workspace/source/builder-maven-32
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-dlang
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-dlang/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-dlang:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-gradle
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-gradle/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-gradle:${inputs.params.version}
                       - --context=/workspace/source
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true
@@ -160,32 +210,66 @@ pipelineConfig:
                     command: /kaniko/warmer
                     args:
                       - --cache-dir=/workspace
-                      - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
                       - --image=gcr.io/jenkinsxio/builder-base:0.0.45
-                      - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
-                  - name: build-and-push-go-maven
+                  - name: build-and-push-gradle4
                     command: /kaniko/executor
                     args:
-                      - --dockerfile=/workspace/source/builder-go-maven/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-go-maven:${inputs.params.version}
-                      - --context=/workspace/source/builder-go-maven
-                      - --cache-repo=gcr.io/jenkinsxio/cache
-                      - --cache=true
-                      - --cache-dir=/workspace
-                  - name: build-and-push-jx
-                    command: /kaniko/executor
-                    args:
-                      - --dockerfile=/workspace/source/builder-jx/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-jx:${inputs.params.version}
+                      - --dockerfile=/workspace/source/builder-gradle4/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-gradle4:${inputs.params.version}
                       - --context=/workspace/source
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true
                       - --cache-dir=/workspace
-                  - name: build-and-push-python
+                  - name: build-and-push-gradle5
                     command: /kaniko/executor
                     args:
-                      - --dockerfile=/workspace/source/builder-python/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-python:${inputs.params.version}
+                      - --dockerfile=/workspace/source/builder-gradle5/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-gradle5:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-gradle5-java11
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-gradle5-java11/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-gradle5-java11:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-maven
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-maven/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-maven:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-newman
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-newman/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-newman:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-nodejs
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-nodejs/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-nodejs:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-nodejs8x
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-nodejs8x/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-nodejs8x:${inputs.params.version}
                       - --context=/workspace/source
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true
@@ -216,174 +300,6 @@ pipelineConfig:
                       - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
                       - --image=gcr.io/jenkinsxio/builder-base:0.0.45
                       - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
-                  - name: build-and-push-maven-32
-                    command: /kaniko/executor
-                    args:
-                      - --dockerfile=/workspace/source/builder-maven-32/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-maven-32:${inputs.params.version}
-                      - --context=/workspace/source/builder-maven-32
-                      - --cache-repo=gcr.io/jenkinsxio/cache
-                      - --cache=true
-                      - --cache-dir=/workspace
-                  - name: build-and-push-dlang
-                    command: /kaniko/executor
-                    args:
-                      - --dockerfile=/workspace/source/builder-dlang/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-dlang:${inputs.params.version}
-                      - --context=/workspace/source
-                      - --cache-repo=gcr.io/jenkinsxio/cache
-                      - --cache=true
-                      - --cache-dir=/workspace
-                  - name: build-and-push-gradle
-                    command: /kaniko/executor
-                    args:
-                      - --dockerfile=/workspace/source/builder-gradle/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-gradle:${inputs.params.version}
-                      - --context=/workspace/source
-                      - --cache-repo=gcr.io/jenkinsxio/cache
-                      - --cache=true
-                      - --cache-dir=/workspace
-              - name: batch-five
-                steps:
-                  - image: centos:7
-                    command: ./replace-versions.sh
-
-                  - image: jenkinsxio/jx:1.3.963
-                    command: jx
-                    args:
-                      - step
-                      - credential
-                      - -s
-                      - kaniko-secret
-                      - -k
-                      - kaniko-secret
-                      - -f
-                      - /builder/home/kaniko-secret.json
-
-                  # cache base images
-                  - name: warm-cache
-                    image: gcr.io/kaniko-project/warmer
-                    command: /kaniko/warmer
-                    args:
-                      - --cache-dir=/workspace
-                      - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
-                      - --image=gcr.io/jenkinsxio/builder-base:0.0.45
-                      - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
-                  - name: build-and-push-gradle4
-                    command: /kaniko/executor
-                    args:
-                      - --dockerfile=/workspace/source/builder-gradle4/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-gradle4:${inputs.params.version}
-                      - --context=/workspace/source
-                      - --cache-repo=gcr.io/jenkinsxio/cache
-                      - --cache=true
-                      - --cache-dir=/workspace
-                  - name: build-and-push-gradle5
-                    command: /kaniko/executor
-                    args:
-                      - --dockerfile=/workspace/source/builder-gradle5/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-gradle5:${inputs.params.version}
-                      - --context=/workspace/source
-                      - --cache-repo=gcr.io/jenkinsxio/cache
-                      - --cache=true
-                      - --cache-dir=/workspace
-                  - name: build-and-push-gradle5-java11
-                    command: /kaniko/executor
-                    args:
-                      - --dockerfile=/workspace/source/builder-gradle5-java11/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-gradle5-java11:${inputs.params.version}
-                      - --context=/workspace/source
-                      - --cache-repo=gcr.io/jenkinsxio/cache
-                      - --cache=true
-                      - --cache-dir=/workspace
-              - name: batch-six
-                steps:
-                  - image: centos:7
-                    command: ./replace-versions.sh
-
-                  - image: jenkinsxio/jx:1.3.963
-                    command: jx
-                    args:
-                      - step
-                      - credential
-                      - -s
-                      - kaniko-secret
-                      - -k
-                      - kaniko-secret
-                      - -f
-                      - /builder/home/kaniko-secret.json
-
-                  # cache base images
-                  - name: warm-cache
-                    image: gcr.io/kaniko-project/warmer
-                    command: /kaniko/warmer
-                    args:
-                      - --cache-dir=/workspace
-                      - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
-                      - --image=gcr.io/jenkinsxio/builder-base:0.0.45
-                      - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
-                  - name: build-and-push-maven
-                    command: /kaniko/executor
-                    args:
-                      - --dockerfile=/workspace/source/builder-maven/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-maven:${inputs.params.version}
-                      - --context=/workspace/source
-                      - --cache-repo=gcr.io/jenkinsxio/cache
-                      - --cache=true
-                      - --cache-dir=/workspace
-                  - name: build-and-push-newman
-                    command: /kaniko/executor
-                    args:
-                      - --dockerfile=/workspace/source/builder-newman/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-newman:${inputs.params.version}
-                      - --context=/workspace/source
-                      - --cache-repo=gcr.io/jenkinsxio/cache
-                      - --cache=true
-                      - --cache-dir=/workspace
-                  - name: build-and-push-nodejs
-                    command: /kaniko/executor
-                    args:
-                      - --dockerfile=/workspace/source/builder-nodejs/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-nodejs:${inputs.params.version}
-                      - --context=/workspace/source
-                      - --cache-repo=gcr.io/jenkinsxio/cache
-                      - --cache=true
-                      - --cache-dir=/workspace
-              - name: batch-seven
-                steps:
-                  - image: centos:7
-                    command: ./replace-versions.sh
-
-                  - image: jenkinsxio/jx:1.3.963
-                    command: jx
-                    args:
-                      - step
-                      - credential
-                      - -s
-                      - kaniko-secret
-                      - -k
-                      - kaniko-secret
-                      - -f
-                      - /builder/home/kaniko-secret.json
-
-                  # cache base images
-                  - name: warm-cache
-                    image: gcr.io/kaniko-project/warmer
-                    command: /kaniko/warmer
-                    args:
-                      - --cache-dir=/workspace
-                      - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
-                      - --image=gcr.io/jenkinsxio/builder-base:0.0.45
-                      - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
-                  - name: build-and-push-nodejs8x
-                    command: /kaniko/executor
-                    args:
-                      - --dockerfile=/workspace/source/builder-nodejs8x/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-nodejs8x:${inputs.params.version}
-                      - --context=/workspace/source
-                      - --cache-repo=gcr.io/jenkinsxio/cache
-                      - --cache=true
-                      - --cache-dir=/workspace
                   - name: build-and-push-nodejs10x
                     command: /kaniko/executor
                     args:
@@ -402,32 +318,6 @@ pipelineConfig:
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true
                       - --cache-dir=/workspace
-              - name: batch-eight
-                steps:
-                  - image: centos:7
-                    command: ./replace-versions.sh
-
-                  - image: jenkinsxio/jx:1.3.963
-                    command: jx
-                    args:
-                      - step
-                      - credential
-                      - -s
-                      - kaniko-secret
-                      - -k
-                      - kaniko-secret
-                      - -f
-                      - /builder/home/kaniko-secret.json
-
-                  # cache base images
-                  - name: warm-cache
-                    image: gcr.io/kaniko-project/warmer
-                    command: /kaniko/warmer
-                    args:
-                      - --cache-dir=/workspace
-                      - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
-                      - --image=gcr.io/jenkinsxio/builder-base:0.0.45
-                      - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
                   - name: build-and-push-ruby
                     command: /kaniko/executor
                     args:
@@ -446,32 +336,6 @@ pipelineConfig:
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true
                       - --cache-dir=/workspace
-              - name: batch-nine
-                steps:
-                  - image: centos:7
-                    command: ./replace-versions.sh
-
-                  - image: jenkinsxio/jx:1.3.963
-                    command: jx
-                    args:
-                      - step
-                      - credential
-                      - -s
-                      - kaniko-secret
-                      - -k
-                      - kaniko-secret
-                      - -f
-                      - /builder/home/kaniko-secret.json
-
-                  # cache base images
-                  - name: warm-cache
-                    image: gcr.io/kaniko-project/warmer
-                    command: /kaniko/warmer
-                    args:
-                      - --cache-dir=/workspace
-                      - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.45
-                      - --image=gcr.io/jenkinsxio/builder-base:0.0.45
-                      - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.45
                   - name: build-and-push-scala
                     command: /kaniko/executor
                     args:


### PR DESCRIPTION
Hopefully maybe possibly this will help cut down on cases of Kaniko plus giant layers running in multiple pods on a single node causing the node to flop over due to `ContainerGCFailed` errors. Still not sure exactly what's causing that - talking with Kaniko people, the error is likely caused by resource contention, and perhaps could be ameliorated with a newer docker version on the nodes, but no one's quite sure. Anyway, this will hopefully help some.

/assign @rawlingsj 
/assign @garethjevans 