### PR TITLE
fix: Use jx version as basis for release version

### DIFF
--- a/builder-gradle/Dockerfile
+++ b/builder-gradle/Dockerfile
@@ -2,8 +2,21 @@ FROM gcr.io/jenkinsxio/builder-base:0.0.66
 
 CMD ["gradle"]
 
-RUN yum install -y java-1.8.0-openjdk-devel
-RUN yum -y groupinstall 'Development Tools'
+ENV ANDROID_VERSION 4333796
+ENV ANDROID_HOME /opt/android-sdk-linux
+ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
+
+RUN yum install -y java-1.8.0-openjdk-devel && \
+    yum -y groupinstall 'Development Tools' && \
+    yum clean all && \
+    wget https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_VERSION}.zip && \
+    unzip sdk-tools-linux-${ANDROID_VERSION}.zip -d android-sdk-linux && \
+    rm sdk-tools-linux-${ANDROID_VERSION}.zip && mv android-sdk-linux /opt/ && \
+    yes | sdkmanager --licenses && \
+    sdkmanager "platform-tools" && \
+    yes | sdkmanager \
+    "platforms;android-28" \
+    "build-tools;28.0.0"
 
 ENV GRADLE_HOME /opt/gradle
 ENV GRADLE_VERSION 4.6
@@ -22,18 +35,6 @@ RUN set -o errexit -o nounset \
 	&& mkdir -p /opt \
 	&& mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
 	&& ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
-
-ENV ANDROID_VERSION 4333796
-ENV ANDROID_HOME /opt/android-sdk-linux
-RUN wget https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_VERSION}.zip && \
-  unzip sdk-tools-linux-${ANDROID_VERSION}.zip -d android-sdk-linux && \
-  rm sdk-tools-linux-${ANDROID_VERSION}.zip && mv android-sdk-linux /opt/
-ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
-RUN yes | sdkmanager --licenses
-RUN sdkmanager "platform-tools"
-RUN yes | sdkmanager \
-    "platforms;android-28" \
-    "build-tools;28.0.0"
 
 # jx
 ENV JX_VERSION 2.0.806

--- a/builder-gradle4/Dockerfile
+++ b/builder-gradle4/Dockerfile
@@ -2,8 +2,21 @@ FROM gcr.io/jenkinsxio/builder-base:0.0.66
 
 CMD ["gradle"]
 
-RUN yum install -y java-1.8.0-openjdk-devel
-RUN yum -y groupinstall 'Development Tools'
+ENV ANDROID_VERSION 4333796
+ENV ANDROID_HOME /opt/android-sdk-linux
+ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
+
+RUN yum install -y java-1.8.0-openjdk-devel && \
+    yum -y groupinstall 'Development Tools' && \
+    yum clean all && \
+    wget https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_VERSION}.zip && \
+    unzip sdk-tools-linux-${ANDROID_VERSION}.zip -d android-sdk-linux && \
+    rm sdk-tools-linux-${ANDROID_VERSION}.zip && mv android-sdk-linux /opt/ && \
+    yes | sdkmanager --licenses && \
+    sdkmanager "platform-tools" && \
+    yes | sdkmanager \
+    "platforms;android-28" \
+    "build-tools;28.0.0"
 
 ENV GRADLE_HOME /opt/gradle
 ENV GRADLE_VERSION 4.10.3
@@ -28,19 +41,6 @@ RUN set -o errexit -o nounset \
 	&& mkdir -p /opt \
 	&& mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
 	&& ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
-
-
-ENV ANDROID_VERSION 4333796
-ENV ANDROID_HOME /opt/android-sdk-linux
-RUN wget https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_VERSION}.zip && \
-  unzip sdk-tools-linux-${ANDROID_VERSION}.zip -d android-sdk-linux && \
-  rm sdk-tools-linux-${ANDROID_VERSION}.zip && mv android-sdk-linux /opt/
-ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
-RUN yes | sdkmanager --licenses
-RUN sdkmanager "platform-tools"
-RUN yes | sdkmanager \
-    "platforms;android-28" \
-    "build-tools;28.0.0"
 
 # jx
 ENV JX_VERSION 2.0.806

--- a/builder-gradle5/Dockerfile
+++ b/builder-gradle5/Dockerfile
@@ -2,8 +2,21 @@ FROM gcr.io/jenkinsxio/builder-base:0.0.66
 
 CMD ["gradle"]
 
-RUN yum install -y java-1.8.0-openjdk-devel
-RUN yum -y groupinstall 'Development Tools'
+ENV ANDROID_VERSION 4333796
+ENV ANDROID_HOME /opt/android-sdk-linux
+ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
+
+RUN yum install -y java-1.8.0-openjdk-devel && \
+    yum -y groupinstall 'Development Tools' && \
+    yum clean all && \
+    wget https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_VERSION}.zip && \
+    unzip sdk-tools-linux-${ANDROID_VERSION}.zip -d android-sdk-linux && \
+    rm sdk-tools-linux-${ANDROID_VERSION}.zip && mv android-sdk-linux /opt/ && \
+    yes | sdkmanager --licenses && \
+    sdkmanager "platform-tools" && \
+    yes | sdkmanager \
+    "platforms;android-28" \
+    "build-tools;28.0.0"
 
 ENV GRADLE_HOME /opt/gradle
 ENV GRADLE_VERSION 5.6.2
@@ -29,19 +42,6 @@ RUN set -o errexit -o nounset \
 	&& mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
 	&& ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
 
-
-ENV ANDROID_VERSION 4333796
-ENV ANDROID_HOME /opt/android-sdk-linux
-RUN wget https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_VERSION}.zip && \
-  unzip sdk-tools-linux-${ANDROID_VERSION}.zip -d android-sdk-linux && \
-  rm sdk-tools-linux-${ANDROID_VERSION}.zip && mv android-sdk-linux /opt/
-ENV PATH ${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
-RUN yes | sdkmanager --licenses
-RUN sdkmanager "platform-tools"
-RUN yes | sdkmanager \
-    "platforms;android-28" \
-    "build-tools;28.0.0"
-	
 RUN gradle --version
 
 # jx

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -417,6 +417,11 @@ pipelineConfig:
                       - --cache=true
                       - --cache-dir=/workspace
     release:
+      setVersion:
+        steps:
+          - name: next-version
+            sh: "jx step next-version --version $(jx step get dependency-version --host=github.com --owner=jenkins-x --repo=jx --dir . | sed 's/.*: \\(.*\\)/\\1/')-${BUILD_NUMBER} --tag"
+
       pipeline:
         options:
           containerOptions:

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -31,7 +31,7 @@ pipelineConfig:
               - name: GIT_AUTHOR_NAME
                 value: jenkins-x-bot
             parallel:
-              - name: batch-one
+              - name: batch-1
                 steps:
                 - image: centos:7
                   command: ./replace-versions.sh
@@ -84,43 +84,34 @@ pipelineConfig:
                     - --cache-repo=gcr.io/jenkinsxio/cache
                     - --cache=true
                     - --cache-dir=/workspace
-                - name: build-and-push-cf
+                - name: build-and-push-maven
                   command: /kaniko/executor
                   args:
-                    - --dockerfile=/workspace/source/builder-cf/Dockerfile
-                    - --destination=gcr.io/jenkinsxio/builder-cf:${inputs.params.version}
+                    - --dockerfile=/workspace/source/builder-maven/Dockerfile
+                    - --destination=gcr.io/jenkinsxio/builder-maven:${inputs.params.version}
                     - --context=/workspace/source
                     - --cache-repo=gcr.io/jenkinsxio/cache
                     - --cache=true
                     - --cache-dir=/workspace
-                - name: build-and-push-go
+                - name: build-and-push-python
                   command: /kaniko/executor
                   args:
-                    - --dockerfile=/workspace/source/builder-go/Dockerfile
-                    - --destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}
+                    - --dockerfile=/workspace/source/builder-python/Dockerfile
+                    - --destination=gcr.io/jenkinsxio/builder-python:${inputs.params.version}
                     - --context=/workspace/source
                     - --cache-repo=gcr.io/jenkinsxio/cache
                     - --cache=true
                     - --cache-dir=/workspace
-                - name: build-and-push-python37
+                - name: build-and-push-maven-32
                   command: /kaniko/executor
                   args:
-                    - --dockerfile=/workspace/source/builder-python37/Dockerfile
-                    - --destination=gcr.io/jenkinsxio/builder-python37:${inputs.params.version}
-                    - --context=/workspace/source
+                    - --dockerfile=/workspace/source/builder-maven-32/Dockerfile
+                    - --destination=gcr.io/jenkinsxio/builder-maven-32:${inputs.params.version}
+                    - --context=/workspace/source/builder-maven-32
                     - --cache-repo=gcr.io/jenkinsxio/cache
                     - --cache=true
                     - --cache-dir=/workspace
-                - name: build-and-push-nodejs12x
-                  command: /kaniko/executor
-                  args:
-                    - --dockerfile=/workspace/source/builder-nodejs12x/Dockerfile
-                    - --destination=gcr.io/jenkinsxio/builder-nodejs12x:${inputs.params.version}
-                    - --context=/workspace/source
-                    - --cache-repo=gcr.io/jenkinsxio/cache
-                    - --cache=true
-                    - --cache-dir=/workspace
-              - name: batch-two
+              - name: batch-2
                 steps:
                   - image: centos:7
                     command: ./replace-versions.sh
@@ -153,30 +144,21 @@ pipelineConfig:
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true
                       - --cache-dir=/workspace
-                  - name: build-and-push-jx
+                  - name: build-and-push-go
                     command: /kaniko/executor
                     args:
-                      - --dockerfile=/workspace/source/builder-jx/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-jx:${inputs.params.version}
+                      - --dockerfile=/workspace/source/builder-go/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-go:${inputs.params.version}
                       - --context=/workspace/source
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true
                       - --cache-dir=/workspace
-                  - name: build-and-push-python
+                  - name: build-and-push-terraform
                     command: /kaniko/executor
                     args:
-                      - --dockerfile=/workspace/source/builder-python/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-python:${inputs.params.version}
+                      - --dockerfile=/workspace/source/builder-terraform/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-terraform:${inputs.params.version}
                       - --context=/workspace/source
-                      - --cache-repo=gcr.io/jenkinsxio/cache
-                      - --cache=true
-                      - --cache-dir=/workspace
-                  - name: build-and-push-maven-32
-                    command: /kaniko/executor
-                    args:
-                      - --dockerfile=/workspace/source/builder-maven-32/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-maven-32:${inputs.params.version}
-                      - --context=/workspace/source/builder-maven-32
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true
                       - --cache-dir=/workspace
@@ -185,15 +167,6 @@ pipelineConfig:
                     args:
                       - --dockerfile=/workspace/source/builder-dlang/Dockerfile
                       - --destination=gcr.io/jenkinsxio/builder-dlang:${inputs.params.version}
-                      - --context=/workspace/source
-                      - --cache-repo=gcr.io/jenkinsxio/cache
-                      - --cache=true
-                      - --cache-dir=/workspace
-                  - name: build-and-push-gradle
-                    command: /kaniko/executor
-                    args:
-                      - --dockerfile=/workspace/source/builder-gradle/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-gradle:${inputs.params.version}
                       - --context=/workspace/source
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true
@@ -216,7 +189,7 @@ pipelineConfig:
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true
                       - --cache-dir=/workspace
-              - name: batch-three
+              - name: batch-3
                 steps:
                   - image: centos:7
                     command: ./replace-versions.sh
@@ -240,6 +213,15 @@ pipelineConfig:
                     args:
                       - --cache-dir=/workspace
                       - --image=gcr.io/jenkinsxio/builder-base:0.0.66
+                  - name: build-and-push-gradle
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-gradle/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-gradle:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
                   - name: build-and-push-gradle4
                     command: /kaniko/executor
                     args:
@@ -267,24 +249,6 @@ pipelineConfig:
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true
                       - --cache-dir=/workspace
-                  - name: build-and-push-maven
-                    command: /kaniko/executor
-                    args:
-                      - --dockerfile=/workspace/source/builder-maven/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-maven:${inputs.params.version}
-                      - --context=/workspace/source
-                      - --cache-repo=gcr.io/jenkinsxio/cache
-                      - --cache=true
-                      - --cache-dir=/workspace
-                  - name: build-and-push-newman
-                    command: /kaniko/executor
-                    args:
-                      - --dockerfile=/workspace/source/builder-newman/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-newman:${inputs.params.version}
-                      - --context=/workspace/source
-                      - --cache-repo=gcr.io/jenkinsxio/cache
-                      - --cache=true
-                      - --cache-dir=/workspace
                   - name: build-and-push-nodejs
                     command: /kaniko/executor
                     args:
@@ -303,7 +267,7 @@ pipelineConfig:
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true
                       - --cache-dir=/workspace
-              - name: batch-four
+              - name: batch-4
                 steps:
                   - image: centos:7
                     command: ./replace-versions.sh
@@ -329,6 +293,15 @@ pipelineConfig:
                       - --image=gcr.io/jenkinsxio/builder-swiftbase:0.0.66
                       - --image=gcr.io/jenkinsxio/builder-base:0.0.66
                       - --image=gcr.io/jenkinsxio/builder-rubybase:0.0.66
+                  - name: build-and-push-jx
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-jx/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-jx:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
                   - name: build-and-push-nodejs10x
                     command: /kaniko/executor
                     args:
@@ -356,15 +329,6 @@ pipelineConfig:
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true
                       - --cache-dir=/workspace
-                  - name: build-and-push-rust
-                    command: /kaniko/executor
-                    args:
-                      - --dockerfile=/workspace/source/builder-rust/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-rust:${inputs.params.version}
-                      - --context=/workspace/source
-                      - --cache-repo=gcr.io/jenkinsxio/cache
-                      - --cache=true
-                      - --cache-dir=/workspace
                   - name: build-and-push-scala
                     command: /kaniko/executor
                     args:
@@ -383,11 +347,71 @@ pipelineConfig:
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true
                       - --cache-dir=/workspace
-                  - name: build-and-push-terraform
+              - name: batch-5
+                steps:
+                  - image: centos:7
+                    command: ./replace-versions.sh
+
+                  - image: jenkinsxio/jx:1.3.963
+                    command: jx
+                    args:
+                      - step
+                      - credential
+                      - -s
+                      - kaniko-secret
+                      - -k
+                      - kaniko-secret
+                      - -f
+                      - /builder/home/kaniko-secret.json
+
+                  # cache base images
+                  - name: warm-cache
+                    image: gcr.io/kaniko-project/warmer
+                    command: /kaniko/warmer
+                    args:
+                      - --cache-dir=/workspace
+                      - --image=gcr.io/jenkinsxio/builder-base:0.0.66
+                  - name: build-and-push-python37
                     command: /kaniko/executor
                     args:
-                      - --dockerfile=/workspace/source/builder-terraform/Dockerfile
-                      - --destination=gcr.io/jenkinsxio/builder-terraform:${inputs.params.version}
+                      - --dockerfile=/workspace/source/builder-python37/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-python37:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-nodejs12x
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-nodejs12x/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-nodejs12x:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-newman
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-newman/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-newman:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-cf
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-cf/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-cf:${inputs.params.version}
+                      - --context=/workspace/source
+                      - --cache-repo=gcr.io/jenkinsxio/cache
+                      - --cache=true
+                      - --cache-dir=/workspace
+                  - name: build-and-push-rust
+                    command: /kaniko/executor
+                    args:
+                      - --dockerfile=/workspace/source/builder-rust/Dockerfile
+                      - --destination=gcr.io/jenkinsxio/builder-rust:${inputs.params.version}
                       - --context=/workspace/source
                       - --cache-repo=gcr.io/jenkinsxio/cache
                       - --cache=true

--- a/update-bot.sh
+++ b/update-bot.sh
@@ -18,3 +18,7 @@ jx step create pr chart --name gcr.io/jenkinsxio/builder-ruby --name gcr.io/jenk
 jx step create pr regex --regex "builderTag: (.*)" --version ${VERSION} --files jx-build-templates/values.yaml --repo https://github.com/jenkins-x-charts/jx-build-templates.git
 jx step create pr regex --regex "(?m)^\s+repository: gcr.io/jenkinsxio/builder-[\w-_]+\s+tag: (?P<version>.*)$" --version ${VERSION} --files jenkins-x-platform/values.yaml --files values.yaml --repo https://github.com/jenkins-x/jenkins-x-platform.git
 jx step create pr regex --regex "(?m)^\s+repository: gcr.io/jenkinsxio/builder-maven\s+tag: (?P<version>.*)" --version ${VERSION} --files prow/values.yaml --files environment-controller/values.yaml --repo https://github.com/jenkins-x-charts/prow.git --repo https://github.com/jenkins-x-charts/environment-controller.git
+
+JX_VERSION=$(echo $VERSION|cut -d'-' -f1)
+./build/linux/jx step create pr chart --name jx --version $JX_VERSION  --repo https://github.com/jenkins-x/jenkins-x-platform.git
+./build/linux/jx step create pr regex --regex "\s*jxTag:\s*(.*)" --version $JX_VERSION --files prow/values.yaml --repo https://github.com/jenkins-x-charts/prow.git


### PR DESCRIPTION
Note that this will _not_ work without metapipeline enabled, since it needs `${BUILD_NUMBER}` available. I'm also not 100% sure it'll work at all, but I'm...99% sure?

EDIT: Also started handling https://github.com/jenkins-x/jx/issues/5596 here by updating the JX version in `jenkins-x-platform` and `prow` charts from here. We'll still need to turn off the update in JX. Opening a PR for that.

Also splits to five parallel batches of 6 images per batch (except for one with 5), and reorganizes the builders by batch to stack builders with common layers in the same batch, along with making gradle builders share a common layer.

/assign @cagiti 

fixes https://github.com/jenkins-x/jx/issues/5595
part of https://github.com/jenkins-x/jx/issues/5596