### PR TITLE
feat: Updated graal to current version, added native-image build tools

### DIFF
--- a/builder-maven-graalvm/Dockerfile
+++ b/builder-maven-graalvm/Dockerfile
@@ -10,9 +10,9 @@ ENV PATH $M2:$PATH
 
 # GraalVM
 # https://github.com/quarkusio/quarkus-images/blob/graalvm-1.0.0-rc16/centos-quarkus-maven/Dockerfile
-ARG GRAAL_VERSION=1.0.0-rc16
+ARG GRAAL_VERSION=19.2.1
 
-ENV GRAAL_CE_URL=https://github.com/oracle/graal/releases/download/vm-${GRAAL_VERSION}/graalvm-ce-${GRAAL_VERSION}-linux-amd64.tar.gz
+ENV GRAAL_CE_URL=https://github.com/oracle/graal/releases/download/vm-${GRAAL_VERSION}/graalvm-ce-linux-amd64-${GRAAL_VERSION}.tar.gz
 ARG INSTALL_PKGS="gzip"
 
 ENV GRAALVM_HOME /opt/graalvm
@@ -29,6 +29,8 @@ RUN yum install -y ${INSTALL_PKGS} && \
      rm -rf /var/cache/yum
      ###
 
+ENV PATH $GRAALVM_HOME/bin:$PATH
+RUN gu install native-image
 
 # jx
 ENV JX_VERSION 2.0.893

--- a/builder-maven-graalvm/Dockerfile
+++ b/builder-maven-graalvm/Dockerfile
@@ -9,7 +9,6 @@ ENV M2 $M2_HOME/bin
 ENV PATH $M2:$PATH
 
 # GraalVM
-# https://github.com/quarkusio/quarkus-images/blob/graalvm-1.0.0-rc16/centos-quarkus-maven/Dockerfile
 ARG GRAAL_VERSION=19.2.1
 
 ENV GRAAL_CE_URL=https://github.com/oracle/graal/releases/download/vm-${GRAAL_VERSION}/graalvm-ce-linux-amd64-${GRAAL_VERSION}.tar.gz


### PR DESCRIPTION
Updated Graal to the current version: 19.2.1
Added native image build tools to enable native builds with this builder
Note: "Traditional" builds are still possible