### PR TITLE
fix: update-bot.sh execution needs go now

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -816,7 +816,7 @@ pipelineConfig:
             steps:
             # update downstream dependencies
             - name: update-bot
-              image: gcr.io/jenkinsxio/builder-maven:${inputs.params.version}
+              image: gcr.io/jenkinsxio/builder-go-maven:${inputs.params.version}
               command: ./update-bot.sh
 
             # Create the release notes


### PR DESCRIPTION
So let's run it on a go-maven builder just to be safe in case there
actually is something that needs maven too.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>