### PR TITLE
fix: Update JDK to 11.0.5

### DIFF
--- a/builder-gradle5-java11/Dockerfile
+++ b/builder-gradle5-java11/Dockerfile
@@ -28,8 +28,8 @@ RUN set -o errexit -o nounset \
 
 # JDK 11
 # /home/jenkins/jdk-11.0.2 seems to still be present in final images so let's just force a rm.
-RUN curl https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz | tar -xz && \
-   mv /home/jenkins/jdk-11.0.2 /usr/java && \
+RUN curl https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.5_linux-x64_bin.tar.gz | tar -xz && \
+   mv /home/jenkins/jdk-11.0.5 /usr/java && \
    rm -rf /home/jenkins/jdk-11.0.2
 RUN ln -s /usr/java/bin/java /usr/bin/java
 RUN ln -s /usr/java/bin/javac /usr/bin/javac


### PR DESCRIPTION
Gradle dropped HTTP support from their plugin server last night and it wrought a bit of havoc: https://discuss.gradle.org/t/build-fails-to-resolve-plugin-dependencies-during-planned-tls-1-0-deprecation/33873/4

Builds using this builder will start failing if it continues to use JDK 11.0.2 because of a bug with creating TLS connections. An update to JDK 11.0.5 fixes this.