### PR TITLE
fix: build python37 with SQLite3 support

### DIFF
--- a/builder-python37/Dockerfile
+++ b/builder-python37/Dockerfile
@@ -2,19 +2,19 @@ FROM gcr.io/jenkinsxio/builder-base:0.0.75
 
 ENV PYTHONVERSION 3.7.1
 
-RUN yum -y install gcc openssl-devel bzip2-devel libffi-devel && yum clean all
+RUN yum -y install gcc openssl-devel bzip2-devel libffi-devel libsqlite3x-devel && yum clean all
 
 RUN cd /usr/src && \
     wget https://www.python.org/ftp/python/${PYTHONVERSION}/Python-${PYTHONVERSION}.tgz && \
     tar xzf Python-${PYTHONVERSION}.tgz && \
     cd Python-${PYTHONVERSION} && \
-    ./configure --enable-optimizations && \
+    ./configure --enable-optimizations --enable-loadable-sqlite-extensions && \
     make altinstall && \
     rm /usr/src/Python-${PYTHONVERSION}.tgz && \
     cd ../ && \
     rm -rf /usr/src/Python-${PYTHONVERSION} && \
     ln -fs /usr/local/bin/python3.7 /usr/bin/python3 && \
-    yum -y remove gcc openssl-devel bzip2-devel && \
+    yum -y remove gcc openssl-devel bzip2-devel libsqlite3x-devel && \
     yum clean all && \
     easy_install-3.7 pip && \
     pip install --upgrade pip && \


### PR DESCRIPTION
The current version of builder-python37 is compiled with SQLite3 support:
```bash
➜  builder-python37 git:(master) docker run -it  gcr.io/jenkinsxio/builder-python37 /bin/bashUnable to find image 'gcr.io/jenkinsxio/builder-python37:latest' locally
latest: Pulling from jenkinsxio/builder-python37
Digest: sha256:83ca593cf76e66de6b4eed4d7030eaf95023172f781c04bbca8369e8ddedefb6
Status: Downloaded newer image for gcr.io/jenkinsxio/builder-python37:latest
[root@805a59668c29 jenkins]# python3
Python 3.7.1 (default, Dec 10 2019, 12:38:12)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-39)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sqlite3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/sqlite3/__init__.py", line 23, in <module>
    from sqlite3.dbapi2 import *
  File "/usr/local/lib/python3.7/sqlite3/dbapi2.py", line 27, in <module>
    from _sqlite3 import *
ModuleNotFoundError: No module named '_sqlite3'
>>>
```
This patch is enabling SQLite3 support during Python 3.7.1 compilation.