### PR TITLE
feat: increase Terraform version to 0.12.17

### DIFF
--- a/builder-terraform/Dockerfile
+++ b/builder-terraform/Dockerfile
@@ -1,4 +1,4 @@
-ENV TERRAFORM 0.12.13
+ENV TERRAFORM 0.12.17
 RUN wget https://releases.hashicorp.com/terraform/${TERRAFORM}/terraform_${TERRAFORM}_linux_amd64.zip && \
   unzip terraform_${TERRAFORM}_linux_amd64.zip && \
   chmod +x terraform && mv terraform /usr/bin/terraform && rm terraform_${TERRAFORM}_linux_amd64.zip


### PR DESCRIPTION
In Terraform 0.12.17 they added the trim* functions. I need them for the EKS module.