### PR TITLE
chore: add maven graalvm builder for java 11

### DIFF
--- a/builder-maven-graalvm-java11/Dockerfile
+++ b/builder-maven-graalvm-java11/Dockerfile
@@ -1,0 +1,41 @@
+FROM gcr.io/jenkinsxio/builder-base:0.0.81
+
+RUN yum install -y java-11-openjdk-devel && yum update -y && yum clean all
+
+# Maven
+ENV MAVEN_VERSION 3.6.3
+RUN curl -f -L https://repo1.maven.org/maven2/org/apache/maven/apache-maven/$MAVEN_VERSION/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar -C /opt -xzv
+ENV M2_HOME /opt/apache-maven-$MAVEN_VERSION
+ENV maven.home $M2_HOME
+ENV M2 $M2_HOME/bin
+ENV PATH $M2:$PATH
+
+# GraalVM
+ARG GRAAL_VERSION=20.0.0
+
+ENV GRAAL_CE_URL=https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAAL_VERSION}/graalvm-ce-java11-linux-amd64-${GRAAL_VERSION}.tar.gz
+ARG INSTALL_PKGS="gzip"
+
+ENV GRAALVM_HOME /opt/graalvm
+ENV JAVA_HOME /opt/graalvm
+
+RUN yum install -y ${INSTALL_PKGS} && \
+     ### Installation of GraalVM
+	 mkdir -p ${GRAALVM_HOME} && \
+	 cd ${GRAALVM_HOME} && \
+	 curl -fsSL ${GRAAL_CE_URL} | tar -xzC ${GRAALVM_HOME} --strip-components=1  && \
+     ### Cleanup     
+     yum clean all && \
+     rm -f /tmp/graalvm-ce-amd64.tar.gz && \
+     rm -rf /var/cache/yum
+     ###
+
+ENV PATH $GRAALVM_HOME/bin:$PATH
+RUN gu install native-image
+
+# jx
+ENV JX_VERSION 2.1.30
+RUN curl -f -L https://github.com/jenkins-x/jx/releases/download/v${JX_VERSION}/jx-linux-amd64.tar.gz | tar xzv && \
+  mv jx /usr/bin/
+
+CMD ["mvn","-version"]

--- a/builder-maven-graalvm-java11/Dockerfile
+++ b/builder-maven-graalvm-java11/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/jenkinsxio/builder-base:0.0.81
+FROM gcr.io/jenkinsxio/builder-base:0.0.83
 
 RUN yum install -y java-11-openjdk-devel && yum update -y && yum clean all
 
@@ -34,7 +34,7 @@ ENV PATH $GRAALVM_HOME/bin:$PATH
 RUN gu install native-image
 
 # jx
-ENV JX_VERSION 2.1.30
+ENV JX_VERSION 2.1.85
 RUN curl -f -L https://github.com/jenkins-x/jx/releases/download/v${JX_VERSION}/jx-linux-amd64.tar.gz | tar xzv && \
   mv jx /usr/bin/
 

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -85,6 +85,15 @@ pipelineConfig:
                     - --cache-repo=gcr.io/jenkinsxio/cache
                     - --cache=true
                     - --cache-dir=/workspace
+                - name: build-and-push-maven-graalvm-java11
+                  command: /kaniko/executor
+                  args:
+                    - --dockerfile=/workspace/source/builder-maven-graalvm-java11/Dockerfile
+                    - --destination=gcr.io/jenkinsxio/builder-maven-graalvm-java11:${inputs.params.version}
+                    - --context=/workspace/source
+                    - --cache-repo=gcr.io/jenkinsxio/cache
+                    - --cache=true
+                    - --cache-dir=/workspace
                 - name: build-and-push-maven-nodejs
                   command: /kaniko/executor
                   args:
@@ -503,6 +512,16 @@ pipelineConfig:
                 - --dockerfile=/workspace/source/builder-maven-graalvm/Dockerfile
                 - --destination=gcr.io/jenkinsxio/builder-maven-graalvm:${inputs.params.version}
                 - --destination=gcr.io/jenkinsxio/builder-maven-graalvm:latest
+                - --context=/workspace/source
+                - --cache-repo=gcr.io/jenkinsxio/cache
+                - --cache=true
+                - --cache-dir=/workspace
+            - name: build-and-push-maven-graalvm-java11
+              command: /kaniko/executor
+              args:
+                - --dockerfile=/workspace/source/builder-maven-graalvm-java11/Dockerfile
+                - --destination=gcr.io/jenkinsxio/builder-maven-graalvm-java11:${inputs.params.version}
+                - --destination=gcr.io/jenkinsxio/builder-maven-graalvm-java11:latest
                 - --context=/workspace/source
                 - --cache-repo=gcr.io/jenkinsxio/cache
                 - --cache=true

--- a/update-bot.sh
+++ b/update-bot.sh
@@ -14,6 +14,7 @@ jx step create pr chart --name gcr.io/jenkinsxio/builder-ruby --name gcr.io/jenk
   --name gcr.io/jenkinsxio/builder-python --name gcr.io/jenkinsxio/builder-python2 --name gcr.io/jenkinsxio/builder-python37 \
   --name gcr.io/jenkinsxio/builder-rust --name gcr.io/jenkinsxio/builder-scala --name gcr.io/jenkinsxio/builder-terraform \
   --name gcr.io/jenkinsxio/builder-go-nodejs --name gcr.io/jenkinsxio/builder-dotnet --name gcr.io/jenkinsxio/builder-maven-java14 \
+  --name gcr.io/jenkinsxio/builder-maven-graalvm-java11 \
   --version ${VERSION} --repo https://github.com/jenkins-x/jenkins-x-platform.git
 
 jx step create pr regex --regex "builderTag: (.*)" --version ${VERSION} --files jx-build-templates/values.yaml --repo https://github.com/jenkins-x-charts/jx-build-templates.git


### PR DESCRIPTION
Now that GraalVM + Maven works well with Java 11, it would be good to support this out of the box.

Signed-off-by: Joost van der Griendt <joostvdg@gmail.com>