### PR TITLE
chore: bump graalvm version to 20.0.0

### DIFF
--- a/builder-maven-graalvm/Dockerfile
+++ b/builder-maven-graalvm/Dockerfile
@@ -9,7 +9,7 @@ ENV M2 $M2_HOME/bin
 ENV PATH $M2:$PATH
 
 # GraalVM
-ARG GRAAL_VERSION=19.3.1
+ARG GRAAL_VERSION=20.0.0
 
 ENV GRAAL_CE_URL=https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAAL_VERSION}/graalvm-ce-java11-linux-amd64-${GRAAL_VERSION}.tar.gz
 ARG INSTALL_PKGS="gzip"


### PR DESCRIPTION
We're already quite well into 2020, we might want to update to the 20.20 release of GraalVM.

I'm oke with waiting till there's more than a .0.0 release, but otherwise, this should work fine.

Signed-off-by: Joost van der Griendt <joostvdg@gmail.com>